### PR TITLE
fix(auth): secure logout for API clients and fix cookie cleanup

### DIFF
--- a/src/common/utils/request-token.util.ts
+++ b/src/common/utils/request-token.util.ts
@@ -23,5 +23,17 @@ export function extractAccessToken(request: Request): string | null {
 }
 
 export function extractRefreshToken(request: Request): string | null {
-  return (request as Request & { cookies?: Record<string, string> }).cookies?.refresh_token ?? null;
+  // 优先从cookie读取，其次从请求体读取（与refresh接口逻辑一致）
+  const cookieToken = (request as Request & { cookies?: Record<string, string> }).cookies?.refresh_token;
+  if (cookieToken) {
+    return cookieToken;
+  }
+  
+  // 尝试从请求体获取（对于API/移动端客户端）
+  const body = request.body as any;
+  if (body && typeof body === 'object' && body.refreshToken) {
+    return body.refreshToken;
+  }
+  
+  return null;
 }

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -38,12 +38,31 @@ describe('AuthController', () => {
     const response = {
       clearCookie: jest.fn(),
     } as unknown as Response;
+    
+    // 模拟ConfigService返回值
+    mockConfigService.get.mockImplementation((key: string) => {
+      if (key === 'COOKIE_SAME_SITE') return 'lax';
+      if (key === 'COOKIE_DOMAIN') return undefined;
+      return undefined;
+    });
 
     await controller.logout({ id: 'user-1' }, request, response);
 
     expect(mockAuthService.logout).toHaveBeenCalledWith('user-1', null, 'access-from-header');
-    expect(response.clearCookie).toHaveBeenCalledWith('access_token');
-    expect(response.clearCookie).toHaveBeenCalledWith('refresh_token');
-    expect(response.clearCookie).toHaveBeenCalledWith('csrf_token');
+    expect(response.clearCookie).toHaveBeenCalledWith('access_token', {
+      path: '/',
+      secure: false,
+      sameSite: 'lax',
+    });
+    expect(response.clearCookie).toHaveBeenCalledWith('refresh_token', {
+      path: '/',
+      secure: false,
+      sameSite: 'lax',
+    });
+    expect(response.clearCookie).toHaveBeenCalledWith('csrf_token', {
+      path: '/',
+      secure: false,
+      sameSite: 'lax',
+    });
   });
 });

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -155,10 +155,30 @@ export class AuthController {
     const refreshToken = extractRefreshToken(request);
     const accessToken = extractAccessToken(request);
     await this.authService.logout(currentUser.id, refreshToken, accessToken);
-    // 清除Cookie
-    response.clearCookie('access_token');
-    response.clearCookie('refresh_token');
-    response.clearCookie('csrf_token');
+    
+    // 清除Cookie - 使用与setAuthCookies一致的选项
+    const isProduction = process.env.NODE_ENV === 'production';
+    const configuredSameSite = (this.configService.get<string>('COOKIE_SAME_SITE') || 'lax').toLowerCase();
+    const sameSite = configuredSameSite === 'none' ? 'none' : 'lax';
+    const secure = sameSite === 'none' ? true : isProduction;
+    const cookieDomain = this.configService.get<string>('COOKIE_DOMAIN');
+    const clearCookieOptions: {
+      path: string;
+      secure: boolean;
+      sameSite: 'none' | 'lax';
+      domain?: string;
+    } = {
+      path: '/',
+      secure,
+      sameSite,
+    };
+    if (cookieDomain) {
+      clearCookieOptions.domain = cookieDomain;
+    }
+    
+    response.clearCookie('access_token', clearCookieOptions);
+    response.clearCookie('refresh_token', clearCookieOptions);
+    response.clearCookie('csrf_token', clearCookieOptions);
     return ApiResponseDto.success(null, '登出成功');
   }
 


### PR DESCRIPTION
1. Fix extractRefreshToken to support request body refresh tokens:
   - Previously only read refresh_token from cookies, ignoring request body
   - Now checks cookies first, then request body (matching refresh endpoint logic)
   - Ensures API/mobile client refresh tokens are properly blacklisted on logout
   - Fixes security vulnerability where non-cookie tokens remained valid after logout

2. Fix clearCookie options in logout endpoint:
   - Previously cleared cookies without domain/path options
   - Now passes same options as setAuthCookies (domain, path, secure, sameSite)
   - Ensures domain-scoped cookies are completely removed when COOKIE_DOMAIN configured
   - Fixes incomplete logout issue where browser retained stale auth cookies

Impact:
- ✅ Secure token revocation for all client types (web/API/mobile)
- ✅ Complete cookie cleanup with domain/path consistency
- ✅ Maintains backward compatibility with existing cookie-based clients
- ✅ All backend CI tests pass successfully